### PR TITLE
KAN-321 [FEAT] kafka broker에 올라온 walletdata consumer 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,10 @@ dependencies {
     // Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation group: 'org.json', name: 'json', version: '20231013'
+
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 

--- a/src/main/java/kea/project/reportservice/domain/report/entity/ReportEntity.java
+++ b/src/main/java/kea/project/reportservice/domain/report/entity/ReportEntity.java
@@ -55,4 +55,8 @@ public class ReportEntity extends BaseEntity {
                 .reportEntityState(state)
                 .build();
     }
+
+    public void updateAmount(Integer amount) {
+        this.amount += amount;
+    }
 }

--- a/src/main/java/kea/project/reportservice/domain/report/repository/ReportRepository.java
+++ b/src/main/java/kea/project/reportservice/domain/report/repository/ReportRepository.java
@@ -1,17 +1,22 @@
 package kea.project.reportservice.domain.report.repository;
 
 
+import feign.ResponseMapper;
 import kea.project.reportservice.domain.report.entity.ReportEntity;
 import kea.project.reportservice.domain.report.projection.GetReportProjection;
 import kea.project.reportservice.domain.report.vo.ReportEntityState;
+import kea.project.reportservice.domain.report.vo.WalletType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
 
     List<GetReportProjection> findAllByMemberIdAndConsumedDateAndReportEntityState(Long memberId, LocalDate localDate, ReportEntityState reportEntityState);
+
+    Optional<ReportEntity> findByMemberIdAndConsumedDateAndTypeAndReportEntityState(Long memberId, LocalDate localDate, WalletType walletType, ReportEntityState reportEntityState);
 }

--- a/src/main/java/kea/project/reportservice/kafka/ReportConsumerService.java
+++ b/src/main/java/kea/project/reportservice/kafka/ReportConsumerService.java
@@ -1,0 +1,60 @@
+package kea.project.reportservice.kafka;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kea.project.reportservice.domain.report.entity.ReportEntity;
+import kea.project.reportservice.domain.report.repository.ReportRepository;
+import kea.project.reportservice.domain.report.vo.ReportEntityState;
+import kea.project.reportservice.domain.report.vo.WalletType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ReportConsumerService {
+
+    private final ReportRepository reportRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${spring.kafka.topic.post.name}", groupId = "${spring.kafka.consumer.group-id}")
+    @Transactional
+    public void consume(String message) throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(message);
+        String operation = jsonNode.get("op").asText();
+
+        switch (operation) {
+            case "c":
+                updateReport(jsonNode.get("after"),operation);
+                break;
+            case "d":
+                updateReport(jsonNode.get("before"),operation);
+                break;
+        }
+    }
+
+    private void updateReport(JsonNode node, String operation) {
+        Long memberId = node.get("member_id").asLong();
+        WalletType walletType = WalletType.valueOf(node.get("wallet_type").asText());
+        LocalDate consumedDate = LocalDate.parse(node.get("consumed_date").asText());
+        int amount;
+        if(operation.equals("c"))
+            amount = node.get("amount").asInt();
+        else if(operation.equals("d"))
+            amount = -node.get("amount").asInt();
+        else
+            amount = 0;
+        ReportEntity report = reportRepository.findByMemberIdAndConsumedDateAndTypeAndReportEntityState(memberId, consumedDate, walletType, ReportEntityState.ACTIVE)
+                .map(existingReport -> {
+                    existingReport.updateAmount(amount);
+                    return existingReport;
+                })
+                .orElseGet(() -> ReportEntity.of(memberId, walletType, amount, consumedDate, ReportEntityState.ACTIVE));
+
+        reportRepository.save(report);
+    }
+}

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -1,0 +1,11 @@
+spring:
+  kafka:
+    consumer:
+      bootstrap-servers: ${KAFKA-BROKER}
+      group-id: wallet-to-report
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    topic:
+      post:
+        name: test-debezium-connector

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,4 +8,5 @@ spring:
     include:
       - mysql
       - actuator
+      - kafka
     active: local


### PR DESCRIPTION
wallet table의 데이터는 create, delete만 일어난다. member Id, walletype에 대한 데이터
 가 이미 존재할 경우 update, 존재 하지 않을 경우 create 실행